### PR TITLE
Disable source / destination checks

### DIFF
--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -19,6 +19,12 @@ if test -n "$eni_id"; then
         --device-index 1 \
         --network-interface-id "$eni_id"
 
+    echo "Disabling source/destination checks on $eni_id..."
+    aws ec2 modify-network-interface-attribute \
+        --region "$aws_region" \
+        --network-interface-id "$eni_id" \
+        --no-source-dest-check
+
     while ! ip link show dev eth1; do
         echo "Waiting for ENI to come up..."
         sleep 1

--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -41,6 +41,11 @@ fi
 echo "Enabling ip_forward..."
 sysctl -q -w net.ipv4.ip_forward=1
 
+echo "Disabling reverse path protection..."
+for i in $(find /proc/sys/net/ipv4/conf/ -name rp_filter) ; do
+  echo 0 > $i;
+done
+
 echo "Flushing NAT table..."
 iptables -t nat -F
 

--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -19,12 +19,6 @@ if test -n "$eni_id"; then
         --device-index 1 \
         --network-interface-id "$eni_id"
 
-    echo "Disabling source/destination checks on $eni_id..."
-    aws ec2 modify-network-interface-attribute \
-        --region "$aws_region" \
-        --network-interface-id "$eni_id" \
-        --no-source-dest-check
-
     while ! ip link show dev eth1; do
         echo "Waiting for ENI to come up..."
         sleep 1


### PR DESCRIPTION
This ports most of int128/terraform-aws-nat-instance#51 to `fck-nat`:

* Disable `rp_filter` on all interfaces
* Disable source/destination checks on the ENI used in HA mode

This is untested, but works with that module which is functionally identical.