### PR TITLE
Don't require EIP for HA mode

### DIFF
--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -19,6 +19,12 @@ if test -n "$eni_id"; then
         --device-index 1 \
         --network-interface-id "$eni_id"
 
+    echo "Disabling source/destination checks on $eni_id..."
+    aws ec2 modify-network-interface-attribute \
+        --region "$aws_region" \
+        --network-interface-id "$eni_id" \
+        --no-source-dest-check
+
     while ! ip link show dev eth1; do
         echo "Waiting for ENI to come up..."
         sleep 1

--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -30,12 +30,7 @@ if test -n "$eni_id"; then
         sleep 1
     done
 
-    ec2ifup eth1
-    ec2ifdown eth0
-
-    rm -f /etc/sysconfig/network-scripts/ifcfg-eth0
-
-    nat_interface="eth1"
+    nat_interface="eth0"
 elif test -n "$interface"; then
     echo "Found interface configuration, using $interface"
     nat_interface=$interface

--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -41,6 +41,11 @@ fi
 echo "Enabling ip_forward..."
 sysctl -q -w net.ipv4.ip_forward=1
 
+echo "Disabling reverse path protection..."
+for i in $(find /proc/sys/net/ipv4/conf/ -name rp_filter) ; do
+  echo 0 > $i;
+done
+
 echo "Flushing NAT table..."
 iptables -t nat -F
 


### PR DESCRIPTION
This ports most of int128/terraform-aws-nat-instance#52 to `fck-nat` and builds upon #11.

The only requirement for NAT to work is a functional internet connection, so as the NAT EC2 instance is required to be running on a public subnet, we don't actually need a EIP to get a public IP and therefore an internet connection. (Also they're a very limited resource to be required by a "cheap" NAT solution)

Update the scripting to use eth0 for the upstream internet connection instead of deconfiguring it.

This is untested, but is functionally identical to the referenced pull request in the Terraform module which works in my testing. Note that I have not tested port forwarding _at all_, so it's possible that these changes will break that, however it's unlikely as Linux's routing generally doesn't care where packets come from.

Note that this set of changes _will_ break any system that expects to have an open port on the same IP as it sends from. The fix is to update the port forwarding rules to expect packets on `eth0` instead of `eth1`.