### PR TITLE
Fix ENI id initialization on first boot

### DIFF
--- a/service/fck-nat.service
+++ b/service/fck-nat.service
@@ -2,6 +2,9 @@
 Description = Configure this machine to act as a NAT instance. fck-nat.
 Wants = network-online.target
 After = network-online.target
+# Make sure that the service starts only after cloud init so the EC2 user data
+# script can be executed prior to checking if /etc/fck-nat.conf exists
+After = cloud-final.service
 
 [Service]
 ExecStart = /opt/fck-nat/fck-nat.sh


### PR DESCRIPTION
Hi @AndrewGuenther, thanks a lot for your work!

I've been replacing some NAT Gateways with fck-nat and found an issue when initializing the `$eni_id` environment variable on first boot. Here's what happens when passing user data to the EC2 instances:
- the `fck-nat` service starts before the `cloud-init` service finishes
- `fck-nat.sh` is executed when `/etc/fck-nat.conf` does not exist yet
- `fck-nat.sh` skips modifying and attaching the network interface with `$eni_id`
- on reboot `fck-nat.sh` works as expected because `/etc/fck-nat.conf` already exists 

Tradeoff: this change introduces a minimal delay (~2.5s) to the boot process in favor of correct execution in HA mode.

I believe correct execution delivers more value, but I'm open to discussion.

Without `After = cloud-final.service`

<pre>
[ec2-user@ip-172-31-172-22 ~]$ sudo systemd-analyze --no-pager critical-chain fck-nat.service
The time after the unit is active or started is printed after the "@" character.
The time the unit takes to start is printed after the "+" character.

fck-nat.service +4.732s
└─network-online.target @13.209s
  └─cloud-init.service @11.427s +1.776s
    └─network.service @7.860s +3.562s
      └─network-pre.target @7.859s
        └─cloud-init-local.service @5.881s +1.976s
          └─basic.target @5.627s
            └─sockets.target @5.627s
              └─dbus.socket @5.626s
                └─sysinit.target @5.621s
                  └─systemd-update-utmp.service @5.614s +6ms
                    └─auditd.service @5.169s +443ms
                      └─systemd-tmpfiles-setup.service @5.147s +19ms
                        └─local-fs.target @5.146s
                          └─boot-efi.mount @5.127s +18ms
                            └─dev-disk-by\x2duuid-FAB9\x2d6124.device @5.123s
</pre>

With `After = cloud-final.service`

<pre>
[ec2-user@ip-172-31-172-22 ~]$ sudo systemd-analyze --no-pager critical-chain fck-nat.service
The time after the unit is active or started is printed after the "@" character.
The time the unit takes to start is printed after the "+" character.

fck-nat.service +2.580s
└─<b>cloud-final.service @15.349s +461ms</b>
  └─<b>cloud-config.service @13.218s +2.128s</b>
    └─network-online.target @13.209s
      └─cloud-init.service @11.427s +1.776s
        └─network.service @7.860s +3.562s
          └─network-pre.target @7.859s
            └─cloud-init-local.service @5.881s +1.976s
              └─basic.target @5.627s
                └─sockets.target @5.627s
                  └─dbus.socket @5.626s
                    └─sysinit.target @5.621s
                      └─systemd-update-utmp.service @5.614s +6ms
                        └─auditd.service @5.169s +443ms
                          └─systemd-tmpfiles-setup.service @5.147s +19ms
                            └─local-fs.target @5.146s
                              └─boot-efi.mount @5.127s +18ms
                                └─dev-disk-by\x2duuid-FAB9\x2d6124.device @5.123s
</pre>

The instances are being provisioned with Terraform (based on the [CloudFormation template](https://fck-nat.dev/deploying/)) but using launch templates instead of launch configs.

Cheers!