### PR TITLE
Fixes failing attach network when already used

### DIFF
--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -23,11 +23,14 @@ if test -n "$eni_id"; then
         --network-interface-id "$eth0_eni_id" \
         --no-source-dest-check
 
-    aws ec2 attach-network-interface \
+    while ! aws ec2 attach-network-interface \
         --region "$aws_region" \
         --instance-id "$instance_id" \
         --device-index 1 \
-        --network-interface-id "$eni_id"
+        --network-interface-id "$eni_id"; do
+        echo "Waiting for ENI to attach..."
+        sleep 5
+    done
 
     while ! ip link show dev eth1; do
         echo "Waiting for ENI to come up..."


### PR DESCRIPTION
When using with ASG, the instance would sometimes fail to attach the ENI as it'd still be used by the other instance being terminated. This would not happen in every cases, but when it'd happen, the instance would be in a failed state where it'd wait for the interface to be attached, which would never happen as the attach network command is not retried.

When happening, manually attaching the ENI would unstuck the instance from its deadlock.

As an alternative way and instead of using a loop, this could probably be fixed by adding the [DetachNetworkInterface](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DetachNetworkInterface.html), and detaching the ENI from the instance it is currently attached before attaching it to the new instance.