### PR TITLE
Option to use NAT instance with existing EIP

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -166,6 +166,15 @@ Resources:
                 Resource: "*"
             Version: "2012-10-17"
           PolicyName: attachNatEniPolicy
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - ec2:AssociateAddress
+                  - ec2:DisassociateAddress
+                Effect: Allow
+                Resource: "*"
+            Version: "2012-10-17"
+          PolicyName: attachNatEniPolicy
 ```
 
 ## Manual - Web Console

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,12 +4,14 @@
 
 fck-nat can operate on a single instance, or withing an autoscaling group for improved availability. When running in an
 autoscaling group, fck-nat can be configured to always attach a specific ENI at start-up, allowing fck-nat to maintain
-a consistent internal-facing IP address.
+a consistent internal-facing IP address. Additionally, it is also possible to configure an already allocated EIP address
+that would be carried through instance refreshs.
 
-To enable this feature, you'll need to create a config file at `/etc/fck-nat.conf` like this:
+To enable these features, you'll need to create a config file at `/etc/fck-nat.conf` like this:
 
 ```
 eni_id=<YOUR_ENI_ID>
+eip_id=<YOUR_EIP_ALLOCATION_ID>
 ```
 
 Once the fck-nat configuration is created, be sure to restart the service by running `service fck-nat restart`.

--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -7,17 +7,27 @@ else
     echo "No fck-nat configuration at /etc/fck-nat.conf"
 fi
 
+aws_region="$(/opt/aws/bin/ec2-metadata -z | cut -f2 -d' ' | sed 's/.$//')"
+eth0_mac="$(cat /sys/class/net/eth0/address)"
+token="$(curl -X PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 300' http://169.254.169.254/latest/api/token)"
+eth0_eni_id="$(curl -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/network/interfaces/macs/$eth0_mac/interface-id)"
+
+if test -n "$eip_id"; then
+    echo "Found eip_id configuration, associating $eip_id..."
+
+    aws ec2 associate-address \
+        --region "$aws_region" \
+        --allocation-id "$eip_id" \
+        --network-interface-id "$eth0_eni_id" \
+        --allow-reassociation
+    sleep 3
+fi
+
 if test -n "$eni_id"; then
     echo "Found eni_id configuration, attaching $eni_id..."
 
-    aws_region="$(/opt/aws/bin/ec2-metadata -z | cut -f2 -d' ' | sed 's/.$//')"
     instance_id="$(/opt/aws/bin/ec2-metadata -i | cut -f2 -d' ')"
 
-    eth0_mac="$(cat /sys/class/net/eth0/address)"
-    
-    token="$(curl -X PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 300' http://169.254.169.254/latest/api/token)"
-    eth0_eni_id="$(curl -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/network/interfaces/macs/$eth0_mac/interface-id)"
-    
     aws ec2 modify-network-interface-attribute \
         --region "$aws_region" \
         --network-interface-id "$eth0_eni_id" \


### PR DESCRIPTION
This PR gives support for static EIP by allowing instance to allocate itself an EIP passed as parameter to its public interface (`eth0`). This ensures network always flows through the same IP even in case of instance recreation / failure.

A few points to note in this PR:
- Once assigned, a `sleep 3` is issued to ensure the instance network networking is functional as I encountered cases where a direct egress interaction following EIP change would result in failure
- I added IAM permissions on the documentation Cloudformation, without adding a way to actually pass an EIP allocation as I am fairly unfamiliar with Cloudformation
- A few user data API calls were shifted from the `eni_id` scope to the global scope so that those variables may be reused in other blocks (in this case `eip_id`)

This PR only adds support for the service to have an EIP. This change is compatible with current implementations of CDK and Cloudformation, but they will need to be updated to pass the `eip_id` parameter to the configuration in order to have static EIP support.