### PR TITLE
Amazon SSM Agent

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -76,3 +76,18 @@ Ensure you are aware of Cloudwatch metrics costs before enabling Cloudwatch agen
 cost you about $17/monthly, excluding free tier.  
 
 **IAM requirements**: `ssm:GetParameter` on the SSM Parameter ARN, and `cloudwatch:PutMetricData` on `*`.
+
+## Session Manager
+
+fck-nat disables SSH by default in favour of Session Manager available through Amazon SSM Agent. Connecting to the
+instance may be achieved either directly through the AWS console, or via the command
+`aws ssm start-session --target i-abc1234` provided you have required IAM permission.  
+
+If you wish to use SSH nonetheless, you may re-enable the service through EC2's user-data with the following commands:
+```
+sudo systemctl unmask sshd
+sudo systemctl enable sshd
+sudo systemctl start sshd
+```  
+
+**IAM requirements**: Attach AWS managed policy `AmazonSSMManagedInstanceCore` to the role of your instance profile. 

--- a/packer/fck-nat.pkr.hcl
+++ b/packer/fck-nat.pkr.hcl
@@ -100,8 +100,7 @@ build {
       "sudo yum install amazon-cloudwatch-agent -y",
       "sudo yum install amazon-ssm-agent -y",
       "sudo systemctl disable sshd",
-      "sudo systemctl mask sshd",
-      "sudo yum remove postfix -y"
+      "sudo systemctl mask sshd"
     ]
   }
 }

--- a/packer/fck-nat.pkr.hcl
+++ b/packer/fck-nat.pkr.hcl
@@ -97,7 +97,11 @@ build {
   provisioner "shell" {
     inline = [
       "sudo yum --nogpgcheck -y localinstall /tmp/fck-nat-${var.version}-any.rpm",
-      "sudo yum install amazon-cloudwatch-agent -y"
+      "sudo yum install amazon-cloudwatch-agent -y",
+      "sudo yum install amazon-ssm-agent -y",
+      "sudo systemctl disable sshd",
+      "sudo systemctl mask sshd",
+      "sudo yum remove postfix -y"
     ]
   }
 }

--- a/packer/fck-nat.pkr.hcl
+++ b/packer/fck-nat.pkr.hcl
@@ -99,8 +99,6 @@ build {
     inline = [
       "sudo yum install amazon-cloudwatch-agent amazon-ssm-agent iptables -y",
       "sudo yum --nogpgcheck -y localinstall /tmp/fck-nat-${var.version}-any.rpm",
-      "sudo yum install amazon-cloudwatch-agent -y",
-      "sudo yum install amazon-ssm-agent -y",
       "sudo systemctl disable sshd",
       "sudo systemctl mask sshd"
     ]


### PR DESCRIPTION
Disables SSH by default. Also looked into services running on the image and found out a couple of them are listening from every interfaces. The following a list of listening ports with their service:

```
chronyd   466   chrony    5u  IPv4  13301      0t0  UDP 127.0.0.1:323 
chronyd   466   chrony    6u  IPv6  13302      0t0  UDP [::1]:323 
dhclient  679     root    6u  IPv4  13764      0t0  UDP *:bootpc 
dhclient  728     root    5u  IPv6  13966      0t0  UDP [xx::xx:xx:xx:xx]:dhcpv6-client 
master    875     root   13u  IPv4  14988      0t0  TCP 127.0.0.1:smtp (LISTEN)
sshd     1011     root    3u  IPv4  16519      0t0  TCP *:ssh (LISTEN)
sshd     1011     root    4u  IPv6  16528      0t0  TCP *:ssh (LISTEN)
dhclient 1238     root    6u  IPv4  16377      0t0  UDP *:bootpc 
dhclient 1289     root    5u  IPv6  17166      0t0  UDP [xx::xx:xx:xx:xx]:dhcpv6-client 
sshd     1319     root    3u  IPv4  17203      0t0  TCP 10.255.255.13:ssh->xx.xx.xx.xx:17638 (ESTABLISHED)
sshd     1322 ec2-user    3u  IPv4  17203      0t0  TCP 10.255.255.13:ssh->xx.xx.xx.xx:17638 (ESTABLISHED)
```

The PR already removes both postfix and disables SSH. This leaves `dhclient` listening on * for TCP and UDP IPv4. I left it as is as I am not familiar enough with this part on AWS and am not sure if there would be unexpected side effects by disabling it.

Additionally, stopping and disabling sshd service was not enough as the service would come back running upon instance reboot. The only proper way I found to prevent it from coming back was to mask the service.

On a second thought we might want to have a PR that would strip the instance out of all its unneeded packages, chrony would be one for example.

EDIT: Removed the line removing postfix, clearing up the clutter might be worth its own PR.