### PR TITLE
Fix ENI failing to re-attach if already assigned

### DIFF
--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -33,19 +33,23 @@ if test -n "$eni_id"; then
         --network-interface-id "$eth0_eni_id" \
         --no-source-dest-check
 
-    while ! aws ec2 attach-network-interface \
-        --region "$aws_region" \
-        --instance-id "$instance_id" \
-        --device-index 1 \
-        --network-interface-id "$eni_id"; do
-        echo "Waiting for ENI to attach..."
-        sleep 5
-    done
+    if ! ip link show dev eth1; then
+        while ! aws ec2 attach-network-interface \
+            --region "$aws_region" \
+            --instance-id "$instance_id" \
+            --device-index 1 \
+            --network-interface-id "$eni_id"; do
+            echo "Waiting for ENI to attach..."
+            sleep 5
+        done
 
-    while ! ip link show dev eth1; do
-        echo "Waiting for ENI to come up..."
-        sleep 1
-    done
+        while ! ip link show dev eth1; do
+            echo "Waiting for ENI to come up..."
+            sleep 1
+        done
+    else
+        echo "eth1 already exists, skipping ENI attachment..."
+    fi
 
     nat_interface="eth0"
 elif test -n "$interface"; then

--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -48,7 +48,13 @@ if test -n "$eni_id"; then
             sleep 1
         done
     else
-        echo "eth1 already exists, skipping ENI attachment..."
+        echo "eth1 already exists, skipping ENI attachment"
+        eth1_mac="$(cat /sys/class/net/eth1/address)"
+        eth1_eni_id="$(curl -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/network/interfaces/macs/$eth1_mac/interface-id)"
+        if test "$eth1_eni_id" != "$eni_id"; then
+            echo "The attached ENI on eth1 ($eth1_eni_id) does not match the configured ENI ($eni_id), aborting"
+            exit 1
+        fi
     fi
 
     nat_interface="eth0"


### PR DESCRIPTION
Further fix to this part of the code. Keeping attach-network-interface in a loop has the side effect of having the instance hanging upon reboot as it is not idempotent and trying to attach a ENI that is already attached causes an error (as opposed to EIP association).