### PR TITLE
NAT64 Support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,9 +8,13 @@ requires the service to be restarted by running `service fck-nat-resart`. In mos
 passed only once via EC2's user data.
 
 The following describes available options:
-| name                    | description |
-| ----------------------- | ----------- |
-| `eni_id`                | The ID of the Elastic Network Interface to attach to the instance and use as a consistent endpoint to send traffic to fck nat. This is required when using high-availability mode. |
-| `eip_id`                | The ID of an Elastic IP to be attached to the public network interface. This ensures the NAT gateway public traffic is always routed through the same public IP address. |
-| `cwagent_enabled`       | If set, enables Cloudwatch agent and forward instance metrics to Cloudwatch. Requires `cwagent_cfg_param_name` to be set. |
-| `cwagent_cfg_param_name` | The name of the SSM Parameter holding the Cloudwatch agent configuration and which the agent shall pull from. Requires `cwagent_enabled` to be set. |
+| name                      | default        | description |
+| -----------------------   | -------------- | ----------- |
+| `eni_id`                  | n/a            | The ID of the Elastic Network Interface to attach to the instance and use as a consistent endpoint to send traffic to fck nat. This is required when using high-availability mode. |
+| `eip_id`                  | n/a            | The ID of an Elastic IP to be attached to the public network interface. This ensures the NAT gateway public traffic is always routed through the same public IP address. |
+| `cwagent_enabled`         | n/a            | If set, enables Cloudwatch agent and forward instance metrics to Cloudwatch. Requires `cwagent_cfg_param_name` to be set. |
+| `cwagent_cfg_param_name`  | n/a            | The name of the SSM Parameter holding the Cloudwatch agent configuration and which the agent shall pull from. Requires `cwagent_enabled` to be set. |
+| `nat64_enabled`           | n/a            | If set, enables NAT64 for the instance. Requires the instance interfaces to have an IPv6 address |
+| `nat64_ipv4_addr`         | 192.168.255.1  | TAYGA's IPv4 address |
+| `nat64_ipv6_addr`         | 2001:db8:1::2  | TAYGA's IPv6 address |
+| `nat64_ipv4_dynamic_pool` | 192.168.0.0/16 | TAYGA's IPv4 dynamic pool. Ideally should have at least as many addresses as IPv6 addresses behing NATed |

--- a/docs/features.md
+++ b/docs/features.md
@@ -76,3 +76,14 @@ Ensure you are aware of Cloudwatch metrics costs before enabling Cloudwatch agen
 cost you about $17/monthly, excluding free tier.  
 
 **IAM requirements**: `ssm:GetParameter` on the SSM Parameter ARN, and `cloudwatch:PutMetricData` on `*`.
+
+## NAT64
+
+fck-nat features NAT64 provided through [TAYGA](http://www.litech.org/tayga/) as a mean to allow IPv6-only networks to
+communicate with external IPv4 networks, working seamlessly with the AWS' DNS64 feature. It's important to note that
+TAYGA comes with its constraint, such as the need of supplying a pool of IPv4 meant to map IPv6 addresses into IPv4, and
+therefore needing to set an unused range across your VPC or peered connections. Refer to [TAYGA's documentation](http://www.litech.org/tayga/README-0.9.2)
+for more information.
+
+Enabling NAT64 can be done by setting `nat64_enabled`, and supports `nat64_ipv4_addr`, `nat64_ipv6_addr`, and
+`nat64_ipv4_dynamic_pool` in fck-nat configuration file. 

--- a/packer/fck-nat.pkr.hcl
+++ b/packer/fck-nat.pkr.hcl
@@ -96,6 +96,16 @@ build {
 
   provisioner "shell" {
     inline = [
+      "sudo yum install bzip2 gcc make -y",
+      "curl http://www.litech.org/tayga/tayga-0.9.2.tar.bz2 -o- | bzip2 -d | tar xvf -",
+      "cd tayga-0.9.2",
+      "./configure && make && sudo make install",
+      "sudo mkdir -p /var/db/tayga"
+    ]
+  }
+
+  provisioner "shell" {
+    inline = [
       "sudo yum --nogpgcheck -y localinstall /tmp/fck-nat-${var.version}-any.rpm",
       "sudo yum install amazon-cloudwatch-agent -y"
     ]

--- a/service/fck-nat.service
+++ b/service/fck-nat.service
@@ -6,6 +6,7 @@ After = network-online.target
 [Service]
 ExecStart = /opt/fck-nat/fck-nat.sh
 Type = oneshot
+RemainAfterExit = yes
 
 [Install]
 WantedBy = multi-user.target

--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -11,8 +11,6 @@ aws_region="$(/opt/aws/bin/ec2-metadata -z | cut -f2 -d' ' | sed 's/.$//')"
 eth0_mac="$(cat /sys/class/net/eth0/address)"
 token="$(curl -X PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 300' http://169.254.169.254/latest/api/token)"
 eth0_eni_id="$(curl -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/network/interfaces/macs/$eth0_mac/interface-id)"
-eth0_ipv4="$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/network/interfaces/macs/$eth0_mac/local-ipv4s | head -n 1)"
-eth0_ipv6="$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/network/interfaces/macs/$eth0_mac/ipv6s | head -n 1)"
 
 if test -n "$eip_id"; then
     echo "Found eip_id configuration, associating $eip_id..."
@@ -49,13 +47,16 @@ if test -n "$eni_id"; then
         sleep 1
     done
 
-    nat_interface="eth0"
+    nat_public_interface="eth0"
+    nat_private_interface="eth1"
 elif test -n "$interface"; then
     echo "Found interface configuration, using $interface"
-    nat_interface=$interface
+    nat_public_interface=$interface
+    nat_private_interface=$nat_public_interface
 else
-    nat_interface=$(ip route | grep default | cut -d ' ' -f 5)
-    echo "No eni_id or interface configuration found, using default interface $nat_interface"
+    nat_public_interface=$(ip route | grep default | cut -d ' ' -f 5)
+    nat_private_interface=$nat_public_interface
+    echo "No eni_id or interface configuration found, using default interface $nat_public_interface"
 fi
 
 echo "Enabling IPv4 forwarding..."
@@ -69,13 +70,17 @@ done
 echo "Flushing IPv4 NAT table..."
 iptables -t nat -F
 
-echo "Adding IPv4 NAT rule..."
-iptables -t nat -A POSTROUTING -o "$nat_interface" -j MASQUERADE -m comment --comment "NAT routing rule installed by fck-nat"
+echo "Adding IPv4 NAT rules..."
+iptables -t nat -A POSTROUTING -o "$nat_public_interface" -j MASQUERADE -m comment --comment "NAT routing rule installed by fck-nat"
 
 if test -n "$nat64_enabled"; then
     echo "Found nat64_enabled configuration, setting up NAT64 via TAYGA..."
+    nat_public_interface_ipv4="$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/network/interfaces/macs/$eth0_mac/local-ipv4s | head -n 1)"
+    nat_public_interface_ipv6="$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/network/interfaces/macs/$eth0_mac/ipv6s | head -n 1)"
+
     pkill tayga
     /usr/local/sbin/tayga --rmtun
+
     cat <<EOF > /usr/local/etc/tayga.conf
 tun-device nat64
 ipv4-addr ${nat64_ipv4_addr:-192.168.255.1}
@@ -84,17 +89,19 @@ prefix 64:ff9b::/96
 dynamic-pool ${nat64_ipv4_dynamic_pool:-192.168.0.0/16}
 data-dir /var/db/tayga
 EOF
+
+    echo "Creating nat64 interface..."
     /usr/local/sbin/tayga --mktun
     ip link set nat64 up
-    ip addr add "$eth0_ipv4" dev nat64
-    ip addr add "$eth0_ipv6" dev nat64
+    ip addr add "$nat_public_interface_ipv4" dev nat64
+    ip addr add "$nat_public_interface_ipv6" dev nat64
     ip route add "${nat64_ipv4_dynamic_pool:-192.168.0.0/16}" dev nat64
     ip route add 64:ff9b::/96 dev nat64
     /usr/local/sbin/tayga
 
     echo "Enabling IPv6 forwarding..."
-    sysctl -q -w net.ipv6.conf.eth0.accept_ra=2
-    sysctl -q -w net.ipv6.conf.eth1.accept_ra=2
+    sysctl -q -w net.ipv6.conf."$nat_public_interface".accept_ra=2
+    sysctl -q -w net.ipv6.conf."$nat_private_interface".accept_ra=2
     sysctl -q -w net.ipv6.conf.all.forwarding=1
 fi
 


### PR DESCRIPTION
This PR adds support for NAT64 through TAYGA. A few things to note:

- Due to TAYGA inner workings, even though installed in the AMI, NAT64 is set to be an opt-in feature
- TAYGA main constraints is that it requires a range of non-used IPv4 addresses to map IPv6 into IPv4 (as described in its documentation), a user would have to ensure this range is not used in any of the subnets needing NAT access
- Seems like networking is a bit buggy on AL2 and `accept_ra` defined in `fck-nat.sh` needs to be set set on a per-interface basis, otherwise the default route of ENI-linked interfaces will be dropped upon turning forwarding on, and AWS VPC networking will be lost. Also forwarding needs to be enabled for `all`, not per-interface (lost an insane amount of time on both those things)
- RemainAfterExit set in the service, as a way to preserve the persisting tayga process

This can be quickly tested with the example on the [nat64 branch](https://github.com/RaJiska/terraform-aws-fck-nat/tree/nat64) of the Terraform fck-nat module I'm working on.

This PR brings the feature discussed in https://github.com/AndrewGuenther/fck-nat/issues/41.