### PR TITLE
NAT64 Support (Jool)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,9 +8,9 @@ requires the service to be restarted by running `service fck-nat-resart`. In mos
 passed only once via EC2's user data.
 
 The following describes available options:
-| name                    | description |
-| ----------------------- | ----------- |
-| `eni_id`                | The ID of the Elastic Network Interface to attach to the instance and use as a consistent endpoint to send traffic to fck nat. This is required when using high-availability mode. |
-| `eip_id`                | The ID of an Elastic IP to be attached to the public network interface. This ensures the NAT gateway public traffic is always routed through the same public IP address. |
-| `cwagent_enabled`       | If set, enables Cloudwatch agent and forward instance metrics to Cloudwatch. Requires `cwagent_cfg_param_name` to be set. |
-| `cwagent_cfg_param_name` | The name of the SSM Parameter holding the Cloudwatch agent configuration and which the agent shall pull from. Requires `cwagent_enabled` to be set. |
+| name                      | default        | description |
+| ------------------------- | -------------- | ----------- |
+| `eni_id`                  | n/a            | The ID of the Elastic Network Interface to attach to the instance and use as a consistent endpoint to send traffic to fck nat. This is required when using high-availability mode. |
+| `eip_id`                  | n/a            | The ID of an Elastic IP to be attached to the public network interface. This ensures the NAT gateway public traffic is always routed through the same public IP address. |
+| `cwagent_enabled`         | n/a            | If set, enables Cloudwatch agent and forward instance metrics to Cloudwatch. Requires `cwagent_cfg_param_name` to be set. |
+| `cwagent_cfg_param_name`  | n/a            | The name of the SSM Parameter holding the Cloudwatch agent configuration and which the agent shall pull from. Requires `cwagent_enabled` to be set. |

--- a/docs/features.md
+++ b/docs/features.md
@@ -76,3 +76,10 @@ Ensure you are aware of Cloudwatch metrics costs before enabling Cloudwatch agen
 cost you about $17/monthly, excluding free tier.  
 
 **IAM requirements**: `ssm:GetParameter` on the SSM Parameter ARN, and `cloudwatch:PutMetricData` on `*`.
+
+## NAT64
+
+fck-nat features NAT64 provided through [jool](https://www.jool.mx/en/index.html) as a mean to allow IPv6-only networks to
+communicate with external IPv4 networks, working seamlessly with the AWS' DNS64 feature.
+
+This feature is built-in and does not require any specific configuration nor need to be explicitly enabled.

--- a/packer/fck-nat.pkr.hcl
+++ b/packer/fck-nat.pkr.hcl
@@ -112,8 +112,8 @@ build {
       "sudo dkms install /tmp/jool-${var.jool_version}",
       "cd /tmp/jool-${var.jool_version}",
       "./configure && make && sudo make install",
-      "sudo rm -rf /tmp/jool-${var.jool_version}"
-      "sudo yum uninstall gcc make elfutils-libelf-devel kernel-devel libnl3-devel iptables-devel -y"
+      "sudo rm -rf /tmp/jool-${var.jool_version}",
+      "sudo yum remove gcc make elfutils-libelf-devel kernel-devel libnl3-devel iptables-devel -y"
     ]
   }
   

--- a/packer/fck-nat.pkr.hcl
+++ b/packer/fck-nat.pkr.hcl
@@ -113,6 +113,7 @@ build {
       "cd /tmp/jool-${var.jool_version}",
       "./configure && make && sudo make install",
       "sudo rm -rf /tmp/jool-${var.jool_version}"
+      "sudo yum uninstall gcc make elfutils-libelf-devel kernel-devel libnl3-devel iptables-devel -y"
     ]
   }
   


### PR DESCRIPTION
Adds NAT64 support through Jool, as a better alternative to the previous NAT64 PR I made with TAYGA (https://github.com/AndrewGuenther/fck-nat/pull/50). As rightfully pointed out in the associated issue (https://github.com/AndrewGuenther/fck-nat/issues/41#issuecomment-1819000799), Jool is a much better alternative than TAYGA as it works as a kernel module rather than the userland TAYGA, in addition of being a stateful (vs stateless) NAT64 implementation as well as having less constraints.

With [Jool](https://www.jool.mx/en/index.html), NAT64 is added as a transparent builtin to fck-nat.

A side effect is that AMI now takes significantly longer to build, about 12 to 14 minutes, whereas it'd previously take about 5 minutes without Jool.