### PR TITLE
Update CloudFormation docs to a fully working example

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -106,14 +106,14 @@ resource "aws_instance" "fck-nat" {
 }
 ```
 
-## Cloudformation
+## CloudFormation
 
 !!! note
-    If you'd be interested in seeing fck-nat published on the Cloudformation registry,
+    If you'd be interested in seeing fck-nat published on the CloudFormation registry,
     [give this issue a +1](https://github.com/AndrewGuenther/cdk-fck-nat/issues/295)
 
 For brevity, this document assumes you already have a VPC with public and private subnets defined in your
-Cloudformation template. This example template provisions the minimum resources required to connect fck-nat in your
+CloudFormation template. This example template provisions the minimum resources required to connect fck-nat in your
 VPC. This is a good option for those that have an existing VPC and NAT Gateway and are looking to switch over. 
 
 1. A security group allowing ingress traffic from within the VPC and egress out to the internet
@@ -128,95 +128,85 @@ This snippet assumes the following resources are already defined:
 
 Steps to deploy:
 
-1. Paste your VPC ID, public subnet ID, and CIDR block into the parameters. Change the [ImageId](index.md#getting-a-fck-nat-ami) based on the region fck-nat is deployed to.
+1. Paste your VPC ID, public subnet ID, VPC CIDR block into the parameters. Change the [FckNatAMIParameter](index.md#getting-a-fck-nat-ami) based on the region fck-nat is deployed to.
 2. Ensure that your public subnet has `Enable auto-assign public IPv4 address` turned on. This can be found in the Console at `VPC > Subnets > Edit subnet settings > Auto-assign IP settings`.
-3. Deploy with cloudformation `aws cloudformation deploy --force-upload --capabilities CAPABILITY_IAM --template-file template.yml --stack-name FckNat`
-4. Add the default route to your route table on the subnet. It is best to do this manually so you can do a seamless cut over from your existing nat gateway. Go to `VPC > Route Tables > Private route table > Routes > Edit Routes` Add a 0.0.0.0/0 route pointing to the network interface.
+3. Deploy with CloudFormation `aws cloudformation deploy --force-upload --capabilities CAPABILITY_IAM --template-file template.yml --stack-name FckNat`
+4. Add the default route to your route table on the subnet. It is best to do this manually so you can do a seamless cut over from your existing NAT gateway. Go to `VPC > Route Tables > Private route table > Routes > Edit Routes` Add a 0.0.0.0/0 route pointing to the network interface.
 
 ``` yaml
 Parameters:
-  vpc:
-    Type: String
-    Default: "vpc-121212121212121212"
-  subnet:
-    Type: String
-    Default: "subnet-121212121212121212"
-  CIDR:
+  VpcIdParameter:
+    Type: AWS::EC2::VPC::Id
+  SubnetIdParameter:
+    Type: AWS::EC2::Subnet::Id
+  CIDRParameter:
     Type: String
     Default: "10.0.0.0/16"
+  FckNatAMIParameter:
+    Type: AWS::EC2::Image::Id
+    Default: ami-075a0093cd9926d44
 
 Resources:
   FckNatInterface:
     Type: AWS::EC2::NetworkInterface
     Properties:
-      SubnetId: !Sub "${subnet}"
+      Description: FckNat Gateway Interface
+      SubnetId: !Ref SubnetIdParameter
       GroupSet:
-        - Fn::GetAtt:
-            - NatSecurityGroup
-            - GroupId
+        - !GetAtt [FckNatSecurityGroup, GroupId]
       SourceDestCheck: false
-      
   FckNatAsgInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Roles:
-        - Ref: NatRole
-
+        - !Ref FckNatRole
   FckNatLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
+    DependsOn: FckNatRole
     Properties:
       LaunchTemplateName: FckNatLaunchTemplate
       LaunchTemplateData:
-        ImageId: ami-05b6d5a2e26f13c93
+        ImageId: !Ref FckNatAMIParameter
         InstanceType: t4g.nano
         IamInstanceProfile:
-          Ref: FckNatAsgInstanceProfile
-        SecurityGroups:
-          - Fn::GetAtt:
-              - NatSecurityGroup
-              - GroupId
+          Name: !Ref FckNatAsgInstanceProfile
+        SecurityGroupIds:
+          - !GetAtt [FckNatSecurityGroup, GroupId]
         UserData:
-          Fn::Base64:
-            Fn::Join:
-              - ""
-              - - |-
-                  #!/bin/bash
-                  echo "eni_id=
-                - Ref: FckNatInterface
-                - |-
-                  " >> /etc/fck-nat.conf
-                  service fck-nat restart
-    DependsOn:
-      - NatRole
-
+          Fn::Base64: !Sub |
+            #!/bin/bash
+            echo "eni_id=${FckNatInterface}" >> /etc/fck-nat.conf
+            service fck-nat restart
   FckNatAsg:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       MaxSize: "1"
       MinSize: "1"
-      DesiredCapacity: "1"
-      LaunchTemplateId:
-        Ref: FckNatLaunchTemplate
+      LaunchTemplate:
+        LaunchTemplateId: !Ref FckNatLaunchTemplate
+        Version: !GetAtt FckNatLaunchTemplate.LatestVersionNumber
       VPCZoneIdentifier:
-        - !Sub "${subnet}"
+        - !Ref SubnetIdParameter
+      Tags:
+        - Key: Name
+          Value: fck-nat
+          PropagateAtLaunch: true
     UpdatePolicy:
       AutoScalingScheduledAction:
         IgnoreUnmodifiedGroupSizeProperties: true
-
-  NatSecurityGroup:
+  FckNatSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Security Group for NAT
-      SecurityGroupIngress: 
-        - CidrIp: !Sub "${CIDR}"
+      GroupDescription: Security Group for FckNat
+      SecurityGroupIngress:
+        - CidrIp: !Ref CIDRParameter
           IpProtocol: "-1"
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0
           Description: Allow all outbound traffic by default
           IpProtocol: "-1"
-      VpcId: !Sub "${vpc}" 
-
-  NatRole:
+      VpcId: !Ref VpcIdParameter
+  FckNatRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -227,7 +217,8 @@ Resources:
               Service: ec2.amazonaws.com
         Version: "2012-10-17"
       Policies:
-        - PolicyDocument:
+        - PolicyName: AttachNatEniPolicy
+          PolicyDocument:
             Statement:
               - Action:
                   - ec2:AttachNetworkInterface
@@ -235,8 +226,8 @@ Resources:
                 Effect: Allow
                 Resource: "*"
             Version: "2012-10-17"
-          PolicyName: attachNatEniPolicy
-        - PolicyDocument:
+        - PolicyName: AssociateNatAddressPolicy
+          PolicyDocument:
             Statement:
               - Action:
                   - ec2:AssociateAddress
@@ -244,7 +235,6 @@ Resources:
                 Effect: Allow
                 Resource: "*"
             Version: "2012-10-17"
-          PolicyName: associateNatAddressPolicy
 ```
 
 ## Manual - Web Console

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -128,7 +128,7 @@ This snippet assumes the following resources are already defined:
 
 Steps to deploy:
 
-1. Paste your VPC ID, public subnet ID, VPC CIDR block into the parameters. Change the [FckNatAMIParameter](index.md#getting-a-fck-nat-ami) based on the region fck-nat is deployed to.
+1. Paste your VPC ID, public subnet ID, VPC CIDR block into the parameters. Set the [FckNatAMIParameter](index.md#getting-a-fck-nat-ami) based on the region fck-nat is deployed to.
 2. Ensure that your public subnet has `Enable auto-assign public IPv4 address` turned on. This can be found in the Console at `VPC > Subnets > Edit subnet settings > Auto-assign IP settings`.
 3. Deploy with CloudFormation `aws cloudformation deploy --force-upload --capabilities CAPABILITY_IAM --template-file template.yml --stack-name FckNat`
 4. Add the default route to your route table on the subnet. It is best to do this manually so you can do a seamless cut over from your existing NAT gateway. Go to `VPC > Route Tables > Private route table > Routes > Edit Routes` Add a 0.0.0.0/0 route pointing to the network interface.
@@ -144,7 +144,6 @@ Parameters:
     Default: "10.0.0.0/16"
   FckNatAMIParameter:
     Type: AWS::EC2::Image::Id
-    Default: ami-075a0093cd9926d44
 
 Resources:
   FckNatInterface:
@@ -182,6 +181,7 @@ Resources:
     Properties:
       MaxSize: "1"
       MinSize: "1"
+      DesiredCapacity: "1"
       LaunchTemplate:
         LaunchTemplateId: !Ref FckNatLaunchTemplate
         Version: !GetAtt FckNatLaunchTemplate.LatestVersionNumber


### PR DESCRIPTION
Fixes a few issues with the CloudFormation docs -

* `AWS::EC2::LaunchTemplate LaunchTemplateData` takes a `IamInstanceProfile` object with a `Name` property, it doesn't accept the name as a value directly.
* `AWS::EC2::LaunchTemplate LaunchTemplateData` requires `SecurityGroupIds` for non-default VPCs (the change here works for both default and non-default VPCs).
* `AWS::AutoScaling::AutoScalingGroup` does not accept `LaunchTemplateId`, it requires a `LaunchTemplate` object containing `LaunchTemplateId` and `Version`.

In addition, this makes a few other changes intending to be helpful but not required -

* Launched instances will be tagged with `fck-nat` in their name, which shows in the EC2 console
* Use the built-in types for CloudFormation parameter selection where available
* Move AMI entry to a parameter
* ~Allow auto scaling group to manage desired capacity (will be set to 1 given 1 min/1 max)~
* User data cleanup with `!Sub`

Great project...thanks for making it!