### PR TITLE
Add packer shell command to remove ssh authorized keys

### DIFF
--- a/packer/fck-nat.pkr.hcl
+++ b/packer/fck-nat.pkr.hcl
@@ -111,4 +111,10 @@ build {
       "sudo systemctl enable kpatch.service && sudo systemctl start kpatch.service",
     ]
   }
+
+  provisioner "shell" {
+    inline = [
+      "rm -f ~/.ssh/authorized_keys"
+    ]
+  }
 }


### PR DESCRIPTION
This should clean the authorized_keys file as a final step to remove the packer SSH key from the distribution.

Note haven't properly tested this, but it should remove the ~/.ssh/authorized_keys file from the final build.