### PR TITLE
docs: use t4g.nano instead of t4g.micro

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -28,7 +28,7 @@ up automatically in case the NAT instance is terminated.
 You can also deploy fck-nat in non-HA mode using CDK's built-in `NatInstanceProvider` like so:
 
 ``` ts
-const natGatewayProvider = new NatInstanceProvider({
+const natGatewayProvider = new NatInstanceProviderV2({
     instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.NANO),
     machineImage: new LookupMachineImage({
         name: 'fck-nat-al2023-*-arm64-ebs',

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -13,7 +13,7 @@ CDK construct in Typescript:
 
 ``` ts
 const natGatewayProvider = new FckNatInstanceProvider({
-    instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
+    instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.NANO),
 });
 const vpc = new Vpc(this, 'vpc', {
     natGatewayProvider,
@@ -29,7 +29,7 @@ You can also deploy fck-nat in non-HA mode using CDK's built-in `NatInstanceProv
 
 ``` ts
 const natGatewayProvider = new NatInstanceProvider({
-    instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
+    instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.NANO),
     machineImage: new LookupMachineImage({
         name: 'fck-nat-al2023-*-arm64-ebs',
         owners: ['568608671756'],


### PR DESCRIPTION
Thanks for this repo! 

Also, the changes in https://github.com/AndrewGuenther/fck-nat/pull/81 are not live in https://fck-nat.dev/stable/deploying/ yet.

Two warnings: Fixed the first one, but I'm not sure where the second is appearing.

```
[WARNING] aws-cdk-lib.aws_ec2.NatInstanceProvider is deprecated.
  use NatInstanceProviderV2. NatInstanceProvider is deprecated since
the instance image used has reached EOL on Dec 31 2023
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_ec2.InstanceProps#keyName is deprecated.
  - Use `keyPair` instead - https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2-readme.html#using-an-existing-ec2-key-pair
  This API will be removed in the next major release.
```