### PR TITLE
Jool (NAT64) 4.1.13 -> 4.1.15 - Fix iptables, Support Linux 6.12-6.18, RHEL 9.5-9.7

### DIFF
--- a/packer/fck-nat.pkr.hcl
+++ b/packer/fck-nat.pkr.hcl
@@ -67,7 +67,7 @@ variable "ssh_username" {
 }
 
 variable "jool_version" {
-  default = "4.1.13"
+  default = "4.1.15"
 }
 
 locals {


### PR DESCRIPTION
Jool (NAT64) 4.1.13 -> 4.1.15 - Fix iptables, Support Linux 6.12-6.18, RHEL 9.5-9.7

NOTE: completely untested.

https://github.com/NICMx/Jool/releases/tag/v4.1.15
>Improvements since 4.1.14:
>
>    Add support for kernels 6.15-6.18
>    Add support for RHEL 9.6, 9.7

https://github.com/NICMx/Jool/releases/tag/v4.1.14
>Improvements since 4.1.13:
>
>    https://github.com/NICMx/Jool/issues/424, https://github.com/NICMx/Jool/issues/432: Fix --iptables
>    Add support for Linux 6.12, 6.13, 6.14 and RHEL 9.5
>   Disable joold debug syslogs by default

Full Changelog: https://github.com/NICMx/Jool/compare/v4.1.13...v4.1.15