### PR TITLE
Remove duplicate ip_forward sysctl from NAT64 merge

### DIFF
--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -81,9 +81,6 @@ if test -n "$ip_local_port_range"; then
   sysctl -q -w net.ipv4.ip_local_port_range="$ip_local_port_range"
 fi
 
-echo "Enabling ip_forward..."
-sysctl -q -w net.ipv4.ip_forward=1
-
 if test -n "$nf_conntrack_max"; then
   sysctl -q -w net.netfilter.nf_conntrack_max="$nf_conntrack_max"
 fi


### PR DESCRIPTION
Fixes #133.

The NAT64 PR (#51) added an "Enabling IPv4 forwarding..." block (lines 77-78 today) that duplicates the existing "Enabling ip_forward..." call (lines 84-85) — both invoke the same `sysctl -q -w net.ipv4.ip_forward=1`.

@AndrewGuenther confirmed the bad-merge diagnosis [in the issue thread](https://github.com/AndrewGuenther/fck-nat/issues/133#issuecomment-4199981314).

This PR drops the older, less-descriptive duplicate. The remaining block (`"Enabling IPv4 forwarding..."`) pairs symmetrically with the existing `"Enabling IPv6 forwarding..."` echo lower in the file.

### Verification

- `sh -n service/fck-nat.sh` passes.
- Only one `net.ipv4.ip_forward` sysctl remains in the script.
- The conditional tunables (`ip_local_port_range`, `nf_conntrack_max`) are untouched.