### PR TITLE
Pin AL2023 var-file base_image_name to kernel 6.12

### DIFF
--- a/packer/fck-nat-al2023.pkrvars.hcl
+++ b/packer/fck-nat-al2023.pkrvars.hcl
@@ -1,3 +1,3 @@
 flavor = "al2023"
-base_image_name = "*al2023-ami-minimal-*-kernel-*"
+base_image_name = "*al2023-ami-minimal-*-kernel-6.12-*"
 base_image_owner = "amazon"


### PR DESCRIPTION
Completes the fix from 8e519c2.

That commit pinned `.pkr.hcl`'s `base_image_name` default to `*al2023-ami-minimal-*-kernel-6.12-*` and updated the NAT64 build provisioner to install `kernel6.12-devel` / `kernel6.12-headers` packages. But `packer/fck-nat-al2023.pkrvars.hcl` still has the older looser pattern `*al2023-ami-minimal-*-kernel-*`, and var-files override `.pkr.hcl` defaults at every `make al2023-ami-*` invocation.

With AWS now publishing kernel 6.18 AL2023 minimal AMIs, `most_recent` picks one of those and the NAT64 build fails on:

```
No match for argument: kernel6.12-devel-6.18.25-55.108.amzn2023.aarch64
No match for argument: kernel6.12-headers-6.18.25-55.108.amzn2023.aarch64
Error: Unable to find a match: kernel6.12-devel-6.18.25-55.108.amzn2023.aarch64 kernel6.12-headers-6.18.25-55.108.amzn2023.aarch64
```

Hit this while validating #127 — full trace in [that review](https://github.com/AndrewGuenther/fck-nat/pull/127#pullrequestreview). Mirroring the `.pkr.hcl` pin into the var-file unblocks `make al2023-ami-nat64-{arm64,x86}` against the current AL2023 AMI catalog.

## Verification

After this patch, `make al2023-ami-nat64-arm64` builds clean against `ami-051432360381493b4` (kernel `6.12.83-113.160.amzn2023.aarch64`):

- `Installing /lib/modules/6.12.83-113.160.amzn2023.aarch64/extra/jool.ko` ✅
- Userspace `./configure && make && sudo make install` ✅
- Total build time 22m27s, AMI registered + cleaned up

## Alternatives considered

Removing the `base_image_name` line from the var-file entirely (and letting the `.pkr.hcl` default apply) would also work — but the var-file already restates `flavor` and `base_image_owner` the same way, so explicit-mirroring matches the file's existing convention.