### PR TITLE
Add prebuilt gwlbtun build pipeline (unblocks #95 / GWLB)

### DIFF
--- a/.github/workflows/build-gwlbtun.yml
+++ b/.github/workflows/build-gwlbtun.yml
@@ -1,0 +1,100 @@
+name: Build gwlbtun prebuilt artifact
+
+# Builds the AWS Gateway Load Balancer Tunnel Handler (gwlbtun) binary used by
+# fck-nat's GWLB support and publishes it as a versioned .rpm to GitHub release
+# assets. fck-nat's Packer flow consumes the prebuilt .rpm at AMI bake time
+# instead of compiling gwlbtun + Boost inside the AMI itself.
+#
+# See prebuilt/gwlbtun/README.md for design context.
+
+on:
+  workflow_dispatch:
+    inputs:
+      gwlbtun_ref:
+        description: 'aws-samples/aws-gateway-load-balancer-tunnel-handler ref (commit SHA recommended)'
+        required: false
+        default: '5e12604c85e99c8511d5b84604ac49647ffdc395'
+      boost_version:
+        description: 'Boost release version'
+        required: false
+        default: '1.83.0'
+      artifact_version:
+        description: 'Artifact semver (used when no tag is pushed)'
+        required: false
+        default: '0.0.0-dev'
+  push:
+    tags:
+      - 'gwlbtun-v*'
+
+permissions:
+  contents: write   # required for action-gh-release to create/update releases
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rpm_arch: aarch64
+            runner: ubuntu-24.04-arm
+          - rpm_arch: x86_64
+            runner: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve artifact version
+        id: ver
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/gwlbtun-v* ]]; then
+            echo "version=${GITHUB_REF_NAME#gwlbtun-v}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "version=${{ inputs.artifact_version || '0.0.0-dev' }}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Build gwlbtun .rpm inside an AL2023 container
+        run: |
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -w /workspace \
+            -e GWLBTUN_REF='${{ inputs.gwlbtun_ref || '5e12604c85e99c8511d5b84604ac49647ffdc395' }}' \
+            -e BOOST_VERSION='${{ inputs.boost_version || '1.83.0' }}' \
+            -e ARTIFACT_VERSION='${{ steps.ver.outputs.version }}' \
+            -e TARGET_ARCH='${{ matrix.rpm_arch }}' \
+            -e WORKSPACE=/workspace \
+            amazonlinux:2023 \
+            bash prebuilt/gwlbtun/build.sh
+
+      - name: Verify artifact
+        run: |
+          ls -lh build/
+          test -f "build/fck-nat-gwlbtun-${{ steps.ver.outputs.version }}-${{ matrix.rpm_arch }}.rpm"
+
+      - name: Upload artifact (workflow run)
+        uses: actions/upload-artifact@v4
+        with:
+          name: fck-nat-gwlbtun-${{ steps.ver.outputs.version }}-${{ matrix.rpm_arch }}
+          path: build/*.rpm
+          retention-days: 30
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/gwlbtun-v')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List collected artifacts
+        run: find artifacts -type f -name '*.rpm' -exec ls -lh {} \;
+
+      - name: Create release with .rpm assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: artifacts/**/*.rpm

--- a/prebuilt/gwlbtun/README.md
+++ b/prebuilt/gwlbtun/README.md
@@ -1,0 +1,106 @@
+# Prebuilt `gwlbtun` artifact
+
+This directory ships the build pipeline for **`gwlbtun`** — the AWS Gateway
+Load Balancer Tunnel Handler binary that fck-nat uses for GWLB support. The
+binary is built in CI and published as a versioned `.rpm` to GitHub release
+assets. The fck-nat AMI's Packer build downloads the prebuilt artifact instead
+of compiling it inside the AMI.
+
+## Why this exists
+
+The original GWLB support PR ([#95](https://github.com/AndrewGuenther/fck-nat/pull/95))
+compiles `gwlbtun` inline during the Packer AMI build. That approach has two
+problems flagged on the PR thread:
+
+1. **Build deps persist in the AMI.** `cmake`, `gcc`, `g++`, `git`, and a
+   ~500MB Boost source tree end up in the final image unless explicitly
+   cleaned up.
+2. **The source is unpinned.** Packer pulls `--branch main` from the upstream
+   repo at AMI bake time, so reproducible builds are not guaranteed.
+
+This pipeline addresses both: builds happen in a clean CI environment, the
+source is pinned to a specific commit SHA, and only the resulting binary
+(plus a small `BUILD_INFO` provenance file) ends up in the AMI.
+
+## What gets built
+
+A single `.rpm` per architecture:
+
+```
+fck-nat-gwlbtun-<version>-<arch>.rpm
+```
+
+Contents installed under `/opt/aws-gateway-load-balancer-tunnel-handler/`:
+- `gwlbtun` — the compiled binary
+- `BUILD_INFO` — pinning provenance (source SHA, Boost version, build date)
+
+## How to release a new version
+
+1. Bump `GWLBTUN_REF` and/or `BOOST_VERSION` in `.github/workflows/build-gwlbtun.yml`
+   (the `workflow_dispatch` defaults). Pin to a specific commit SHA, not a
+   branch.
+2. Push a tag matching `gwlbtun-v*` (e.g. `gwlbtun-v0.2.0`).
+3. The workflow builds both architectures and publishes a GitHub release with
+   the `.rpm` files attached.
+
+Example:
+
+```sh
+git tag gwlbtun-v0.1.0
+git push origin gwlbtun-v0.1.0
+```
+
+## How the AMI consumes the artifact
+
+The Packer flow downloads and installs the `.rpm`:
+
+```hcl
+provisioner "shell" {
+  inline = [
+    "sudo curl -L -o /tmp/gwlbtun.rpm https://github.com/AndrewGuenther/fck-nat/releases/download/${var.gwlbtun_release}/fck-nat-gwlbtun-${var.gwlbtun_release_version}-${var.rpm_arch}.rpm",
+    "sudo yum --nogpgcheck -y localinstall /tmp/gwlbtun.rpm",
+    "sudo rm /tmp/gwlbtun.rpm",
+  ]
+}
+```
+
+No build tools, no Boost source, no `cmake`/`gcc`/`g++`/`git` in the final
+image. Estimated AMI size reduction vs in-AMI build: ~750 MB.
+
+## Running the build locally (for debugging)
+
+The build script is designed to run inside an AL2023 container so glibc
+matches the target AMI. From the repo root:
+
+```sh
+docker run --rm \
+  -v "$(pwd):/workspace" \
+  -w /workspace \
+  -e GWLBTUN_REF=5e12604c85e99c8511d5b84604ac49647ffdc395 \
+  -e BOOST_VERSION=1.83.0 \
+  -e ARTIFACT_VERSION=0.0.0-local \
+  -e TARGET_ARCH=$(uname -m) \
+  amazonlinux:2023 \
+  bash prebuilt/gwlbtun/build.sh
+```
+
+Output lands in `./build/fck-nat-gwlbtun-0.0.0-local-<arch>.rpm`.
+
+For cross-arch builds (e.g. building aarch64 on an x86_64 host), use Docker's
+emulation via `docker run --platform linux/arm64 ...`. CI builds natively on
+GitHub-hosted `ubuntu-24.04-arm` runners to avoid emulation cost.
+
+## Pinning policy
+
+The workflow's defaults (in `build-gwlbtun.yml`) pin to specific commits and
+versions. Bumping these is a deliberate act:
+
+- **`GWLBTUN_REF`**: only bump after reading the upstream commit log between
+  the current pin and the proposed new pin. The patches we apply
+  (`NO_RETURN_TRAFFIC`, Boost include path) may break if upstream restructures
+  the relevant files.
+- **`BOOST_VERSION`**: only bump after confirming the new Boost version still
+  has the headers `gwlbtun` consumes. Boost API churn is real.
+
+The `BUILD_INFO` file inside each `.rpm` records what was pinned, so any
+running fck-nat instance can be audited via `cat /opt/aws-gateway-load-balancer-tunnel-handler/BUILD_INFO`.

--- a/prebuilt/gwlbtun/build.sh
+++ b/prebuilt/gwlbtun/build.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Build the gwlbtun (AWS Gateway Load Balancer Tunnel Handler) binary and
+# package it as a .rpm.
+#
+# Runs inside an Amazon Linux 2023 container so the linked glibc matches the
+# target fck-nat AMI. Produces:
+#   build/fck-nat-gwlbtun-${ARTIFACT_VERSION}-${TARGET_ARCH}.rpm
+#
+# Inputs (env vars):
+#   GWLBTUN_REF        Commit SHA or ref of aws-samples/aws-gateway-load-balancer-tunnel-handler
+#   BOOST_VERSION      Boost release version (e.g. 1.83.0)
+#   ARTIFACT_VERSION   Semver string for our build (e.g. 0.1.0)
+#   TARGET_ARCH        aarch64 | x86_64 (defaults to uname -m output)
+#   WORKSPACE          Repo root mounted into the container (defaults to /workspace)
+
+set -euo pipefail
+
+GWLBTUN_REF="${GWLBTUN_REF:?GWLBTUN_REF is required (pin to a specific commit SHA)}"
+BOOST_VERSION="${BOOST_VERSION:-1.83.0}"
+ARTIFACT_VERSION="${ARTIFACT_VERSION:-0.0.0-dev}"
+TARGET_ARCH="${TARGET_ARCH:-$(uname -m)}"
+WORKSPACE="${WORKSPACE:-/workspace}"
+
+echo "=== gwlbtun build configuration ==="
+echo "  GWLBTUN_REF      = ${GWLBTUN_REF}"
+echo "  BOOST_VERSION    = ${BOOST_VERSION}"
+echo "  ARTIFACT_VERSION = ${ARTIFACT_VERSION}"
+echo "  TARGET_ARCH      = ${TARGET_ARCH}"
+echo "  WORKSPACE        = ${WORKSPACE}"
+echo
+
+#-------------------------------------------------------------------------------
+# Install build deps (we're in an AL2023 container)
+#-------------------------------------------------------------------------------
+echo "=== Installing build dependencies ==="
+dnf install -y \
+    cmake \
+    gcc gcc-c++ \
+    git \
+    curl \
+    tar \
+    gzip \
+    make \
+    ruby ruby-devel \
+    rpm-build \
+    findutils
+
+# fpm — wraps build outputs into a .rpm without writing an .spec
+gem install --no-document fpm
+
+#-------------------------------------------------------------------------------
+# Stage Boost
+#-------------------------------------------------------------------------------
+echo "=== Downloading Boost ${BOOST_VERSION} ==="
+mkdir -p /tmp/srcs && cd /tmp/srcs
+BOOST_UNDERSCORE="${BOOST_VERSION//./_}"
+curl -fsSL -o boost.tar.gz \
+    "https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_UNDERSCORE}.tar.gz"
+tar xzf boost.tar.gz
+mv "boost_${BOOST_UNDERSCORE}" boost
+rm -f boost.tar.gz
+
+#-------------------------------------------------------------------------------
+# Clone and patch gwlbtun
+#-------------------------------------------------------------------------------
+echo "=== Cloning gwlbtun ${GWLBTUN_REF} ==="
+git clone https://github.com/aws-samples/aws-gateway-load-balancer-tunnel-handler.git gwlbtun
+cd gwlbtun
+git checkout "${GWLBTUN_REF}"
+GWLBTUN_RESOLVED_SHA=$(git rev-parse HEAD)
+echo "Resolved SHA: ${GWLBTUN_RESOLVED_SHA}"
+
+# Mirror the patches PR #95 applied during in-AMI builds.
+# 1. Enable the NO_RETURN_TRAFFIC define for the performance optimization.
+echo "=== Applying patches ==="
+sed -i 's%//#define NO_RETURN_TRAFFIC%#define NO_RETURN_TRAFFIC%' utils.h
+# 2. Point CMakeLists.txt at our staged Boost rather than the upstream-hardcoded path.
+sed -i 's%set(Boost_INCLUDE_DIR /home/ec2-user/boost)%set(Boost_INCLUDE_DIR /tmp/srcs/boost)%' CMakeLists.txt
+
+#-------------------------------------------------------------------------------
+# Compile
+#-------------------------------------------------------------------------------
+echo "=== Compiling gwlbtun ==="
+cmake .
+make -j"$(nproc)"
+
+if [ ! -x "/tmp/srcs/gwlbtun/gwlbtun" ]; then
+    echo "ERROR: build did not produce /tmp/srcs/gwlbtun/gwlbtun" >&2
+    exit 1
+fi
+
+#-------------------------------------------------------------------------------
+# Package as .rpm
+#-------------------------------------------------------------------------------
+echo "=== Packaging .rpm ==="
+STAGE=/tmp/stage
+INSTALL_PREFIX=/opt/aws-gateway-load-balancer-tunnel-handler
+mkdir -p "${STAGE}${INSTALL_PREFIX}"
+install -m 0755 /tmp/srcs/gwlbtun/gwlbtun "${STAGE}${INSTALL_PREFIX}/gwlbtun"
+
+# Embed pinning provenance as a small file in the package so installed AMIs
+# can be audited (which source did this binary come from?).
+mkdir -p "${STAGE}${INSTALL_PREFIX}"
+cat > "${STAGE}${INSTALL_PREFIX}/BUILD_INFO" <<EOF
+gwlbtun source: https://github.com/aws-samples/aws-gateway-load-balancer-tunnel-handler
+gwlbtun commit: ${GWLBTUN_RESOLVED_SHA}
+boost version:  ${BOOST_VERSION}
+build version:  ${ARTIFACT_VERSION}
+target arch:    ${TARGET_ARCH}
+built:          $(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+
+mkdir -p "${WORKSPACE}/build"
+OUTPUT_RPM="${WORKSPACE}/build/fck-nat-gwlbtun-${ARTIFACT_VERSION}-${TARGET_ARCH}.rpm"
+
+fpm -s dir -t rpm \
+    --name fck-nat-gwlbtun \
+    --version "${ARTIFACT_VERSION}" \
+    --architecture "${TARGET_ARCH}" \
+    --license apache-2.0 \
+    --rpm-os linux \
+    --description "AWS Gateway Load Balancer Tunnel Handler, prebuilt for fck-nat.
+Pins to aws-samples/aws-gateway-load-balancer-tunnel-handler commit ${GWLBTUN_RESOLVED_SHA}
+and Boost ${BOOST_VERSION}." \
+    --url "https://github.com/AndrewGuenther/fck-nat" \
+    --maintainer "fck-nat contributors" \
+    -C "${STAGE}" \
+    -p "${OUTPUT_RPM}" \
+    "${INSTALL_PREFIX#/}"
+
+echo
+echo "=== Done. Built: ${OUTPUT_RPM} ==="
+ls -lh "${OUTPUT_RPM}"
+rpm -qip "${OUTPUT_RPM}" || true
+rpm -qlp "${OUTPUT_RPM}" || true


### PR DESCRIPTION
Adds a CI pipeline that builds the AWS Gateway Load Balancer Tunnel Handler (`gwlbtun`) binary externally and publishes it as a versioned `.rpm` to GitHub release assets. PR #95 (GWLB support) can then consume the prebuilt artifact instead of compiling gwlbtun + Boost inline during the Packer AMI build.

This addresses the build-deps concern @ddouglas raised on #95 in 2024 ([comment](https://github.com/AndrewGuenther/fck-nat/pull/95#issuecomment-2291994018)) and @AndrewGuenther agreed with — *"I'll work on cooking something up."* Scoping the externalization separately so it can land independently of #95's other code.

## What changes

- **`.github/workflows/build-gwlbtun.yml`** — workflow_dispatch + tag-triggered build matrix (arm64 + x86_64). Builds inside an `amazonlinux:2023` container so glibc matches the target AMI. Uploads `.rpm` assets to a GitHub release on `gwlbtun-v*` tags.
- **`prebuilt/gwlbtun/build.sh`** — the compile + package script (runs in CI and locally).
- **`prebuilt/gwlbtun/README.md`** — design rationale, release process, pinning policy, local-debugging recipe.

## What the `.rpm` installs

```
/opt/aws-gateway-load-balancer-tunnel-handler/gwlbtun        # the binary
/opt/aws-gateway-load-balancer-tunnel-handler/BUILD_INFO     # provenance (source SHA + Boost version + build date)
```

## Validation (full end-to-end on fork)

I tagged `gwlbtun-v0.1.0` on a fork to exercise the full pipeline. Results:

- ✅ Both build jobs passed (`x86_64`: 77s, `aarch64`: 66s — Boost is header-only here, no Boost compile)
- ✅ Release job published the two `.rpm` files to fork releases: [gwlbtun-v0.1.0 on the fork](https://github.com/SikandAlex/fck-nat/releases/tag/gwlbtun-v0.1.0)
- ✅ `.rpm` installs cleanly in a fresh `amazonlinux:2023` container via `yum --nogpgcheck -y localinstall`
- ✅ Binary runs and identifies itself: `AWS Gateway Load Balancer Tunnel Handler v3.0`
- ✅ `BUILD_INFO` provenance file captured the pinned commit + Boost version + build timestamp
- ✅ Binary is dynamically linked against glibc 2.34 (the AL2023 baseline) — won't run on older hosts, but matches the target AMI exactly

Artifact size: ~320 KB per `.rpm`, installs as 1.5 MB binary + 192 B provenance file.

## What's still in `gwlb/` after this PR

The three small support files added by #95 stay in the fck-nat repo and continue to ship via Packer's `file` provisioner:

- `gwlb-up.sh` — invoked by gwlbtun when tunnels come up/down
- `gwlbtun.conf` — runtime config the systemd unit sources
- `gwlbtun.service` — the systemd unit

Only the compiled binary is externalized — everything else stays in-tree.

## Pinning

The workflow defaults pin:
- gwlbtun source: `aws-samples/aws-gateway-load-balancer-tunnel-handler` commit [`5e12604c85e99c8511d5b84604ac49647ffdc395`](https://github.com/aws-samples/aws-gateway-load-balancer-tunnel-handler/commit/5e12604c85e99c8511d5b84604ac49647ffdc395) (HEAD as of 2025-11-12; vs PR #95's current `--branch main` which is unpinned)
- Boost: `1.83.0` (matches PR #95's current default)

Patches applied during the external build (same as PR #95's current in-AMI build):

```
sed -i 's%//#define NO_RETURN_TRAFFIC%#define NO_RETURN_TRAFFIC%' utils.h
sed -i 's%set(Boost_INCLUDE_DIR /home/ec2-user/boost)%set(Boost_INCLUDE_DIR /tmp/srcs/boost)%' CMakeLists.txt
```

## Cross-cutting note

The same infrastructure pattern would help with Jool/NAT64 (the existing AMI compiles Jool's userspace via `./configure && make && sudo make install`). I'd be happy to follow up with a `prebuilt/jool/` companion in a separate PR if useful, but kept this one scoped to gwlbtun since that's the live merge-blocker.

## What's NOT in this PR

The Packer changes that *consume* the prebuilt artifact. Those belong on PR #95 (since that's where the in-AMI compile lives). I'll propose the corresponding Packer diff as a comment on #95 once this lands — verified end-to-end against the fork's release.

The diff is small (~10 line replacement in the Packer file): swap the dnf/curl/git/cmake/make sequence for a single `curl + yum localinstall` invocation pointing at the GitHub release asset URL.

## Release workflow

Once this PR merges and you tag `gwlbtun-v0.1.0` on this repo, the workflow auto-publishes the assets to the AndrewGuenther/fck-nat releases page. Bumping the pinned upstream commit or Boost version is a deliberate edit to the workflow file + a new tag push.

## Caveats

- This is my first contribution to this repo; the build pipeline pattern is conventional but you may have preferences I haven't anticipated. Happy to iterate.
- The workflow uses GitHub's free-tier `ubuntu-24.04-arm` runner for the arm64 build (available for public repos, no billing).
- `amazonlinux:2023` images come from Docker Hub (`docker.io/library/amazonlinux:2023`) which mirrors AWS's official AL2023 publication.