### PR TITLE
Add production-load kernel-tuning knobs (closes #40)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,10 @@ The following describes available options:
 | `cwagent_cfg_param_name` | The name of the SSM Parameter holding the Cloudwatch agent configuration and which the agent shall pull from. Requires `cwagent_enabled` to be set. |
 | `ip_local_port_range`   | Overrides Linux's `net.ipv4.ip_local_port_range` sysctl for ephemeral source ports used by SNAT. Provide as two space‑separated integers `low high` (e.g., `1024 65535`). Useful to expand the ephemeral port range and reduce NAT port exhaustion and collisions. |
 | `nf_conntrack_max`      | Overrides Linux's `net.netfilter.nf_conntrack_max` sysctl to set the maximum number of concurrently tracked connections. Provide as an integer (e.g., `262144`). Increasing this can help high-connection workloads but consumes more memory; monitor conntrack metrics and AWS security group connection tracking quotas. |
+| `nf_conntrack_buckets`  | Sizes the conntrack hash table (written to `/sys/module/nf_conntrack/parameters/hashsize`). Provide as an integer. A common rule of thumb is `nf_conntrack_max / 4`. Undersizing this with a large `nf_conntrack_max` degrades lookup performance; oversizing wastes memory. |
+| `nf_conntrack_tcp_timeout_established` | Overrides `net.netfilter.nf_conntrack_tcp_timeout_established` (default 432000s = 5 days). Lowering frees conntrack slots from idle established connections faster, at the cost of dropping long-lived idle connections sooner. Useful for high-turnover workloads where the default retention floods the table with stale entries. |
+| `tcp_keepalive_time`    | Overrides `net.ipv4.tcp_keepalive_time` (default 7200s = 2 hours). Interval before the kernel sends the first keepalive probe on an otherwise idle TCP connection. Lower values surface dead peers faster but generate more keepalive traffic. |
+| `tcp_max_syn_backlog`   | Overrides `net.ipv4.tcp_max_syn_backlog` for the maximum number of half-open connections in the SYN queue. Relevant for high-concurrency bursts; raise if `netstat -s` shows SYN queue overflows under load. |
 
 ## IAM Requirements
 

--- a/service/fck-nat.sh
+++ b/service/fck-nat.sh
@@ -88,6 +88,29 @@ if test -n "$nf_conntrack_max"; then
   sysctl -q -w net.netfilter.nf_conntrack_max="$nf_conntrack_max"
 fi
 
+# Optional production-load tuning knobs (see #40).
+# Each is opt-in via /etc/fck-nat.conf — defaults preserve current behavior.
+
+if test -n "$nf_conntrack_buckets"; then
+  # Hash-table sizing for the conntrack store. Rule of thumb: nf_conntrack_max / 4 or 8.
+  # Must be written to /sys (not via sysctl -w which is read-only for this knob).
+  echo "$nf_conntrack_buckets" > /sys/module/nf_conntrack/parameters/hashsize
+fi
+
+if test -n "$nf_conntrack_tcp_timeout_established"; then
+  # Default 432000s (5 days) is too long for many high-turnover NAT workloads.
+  # Lowering frees conntrack slots faster at the cost of dropping idle long-lived connections sooner.
+  sysctl -q -w net.netfilter.nf_conntrack_tcp_timeout_established="$nf_conntrack_tcp_timeout_established"
+fi
+
+if test -n "$tcp_keepalive_time"; then
+  sysctl -q -w net.ipv4.tcp_keepalive_time="$tcp_keepalive_time"
+fi
+
+if test -n "$tcp_max_syn_backlog"; then
+  sysctl -q -w net.ipv4.tcp_max_syn_backlog="$tcp_max_syn_backlog"
+fi
+
 echo "Disabling reverse path protection..."
 for i in $(find /proc/sys/net/ipv4/conf/ -name rp_filter) ; do
   echo 0 > $i;


### PR DESCRIPTION
Issue #40 has been open since Oct 2023 asking for more sysctl knobs to be exposable via `/etc/fck-nat.conf` for production-scale deployments. fck-nat.sh already exposes `ip_local_port_range` and `nf_conntrack_max` via the same opt-in conf pattern; this PR adds four more covering the most common production pain points from the discussion thread.

## What's added

All four are opt-in via `/etc/fck-nat.conf` — defaults preserve current behavior, no impact on existing deployments.

| Var | Maps to | Why it matters |
| --- | --- | --- |
| `nf_conntrack_buckets` | `/sys/module/nf_conntrack/parameters/hashsize` | Sizes the conntrack hash table. Undersizing with a large `nf_conntrack_max` degrades lookups; oversizing wastes memory. Written to `/sys` since `sysctl -w` is read-only for this knob. |
| `nf_conntrack_tcp_timeout_established` | `net.netfilter.nf_conntrack_tcp_timeout_established` | Default 432000s (5 days). High-turnover workloads flood the conntrack table with stale entries waiting for that timeout to expire. |
| `tcp_keepalive_time` | `net.ipv4.tcp_keepalive_time` | Default 7200s (2 hours). Lower values surface dead peers faster. |
| `tcp_max_syn_backlog` | `net.ipv4.tcp_max_syn_backlog` | Raises the SYN queue ceiling. Relevant if `netstat -s` shows SYN queue overflows under load. |

## What's not in this PR (deliberately)

The original #40 thread is wide-ranging. I kept this PR focused on the four knobs that directly map to RaJiska's "conntrack table fills up" concern plus the most common production-NAT pain points (SYN flood handling, idle-connection sweep). Additional knobs (TIME_WAIT reuse, `netdev_max_backlog`, etc.) can land in follow-ups if there's appetite — easier to review small focused PRs against this proven pattern than to ship a "production tuning" kitchen sink in one shot.

## Pattern consistency

Each new knob follows the exact same `if test -n` pattern the existing `ip_local_port_range` and `nf_conntrack_max` knobs use. `docs/configuration.md` updated with the same table-row format.

## Testing

Shell syntax verified (`bash -n service/fck-nat.sh`). Functional tuning verification is workload-dependent — these knobs don't break anything when unset (the default behavior is unchanged), and any value the user sets is applied verbatim, so there's no integration-test surface beyond the `bash -n` syntax check.

Refs: #40