### PR TITLE
Fix package arch metadata and AMI name parameterization

### DIFF
--- a/.fpm
+++ b/.fpm
@@ -1,7 +1,8 @@
 -s dir
 --name fck-nat
 --license mit
---architecture all
+--architecture noarch
+--rpm-os linux
 --description "A NAT instance konfigurator"
 --url "https://github.com/AndrewGuenther/fck-nat"
 --maintainer "Andrew Guenther <guenther.andrew.j@gmail.com>"

--- a/packer/fck-nat.pkr.hcl
+++ b/packer/fck-nat.pkr.hcl
@@ -12,23 +12,27 @@ variable "version" {
 }
 
 variable "ami_regions" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "ami_users" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "ami_groups" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "snapshot_groups" {
-  type = list(string)
+  type    = list(string)
   default = []
+}
+
+variable "prefix" {
+  default = "fck-nat"
 }
 
 variable "virtualization_type" {
@@ -37,6 +41,10 @@ variable "virtualization_type" {
 
 variable "architecture" {
   default = "arm64"
+}
+
+variable "suffix" {
+  default = "ebs"
 }
 
 variable "flavor" {
@@ -103,7 +111,7 @@ locals {
 }
 
 source "amazon-ebs" "fck-nat" {
-  ami_name                  = "fck-nat-${var.flavor}-${var.virtualization_type}-${var.version}-${formatdate("YYYYMMDD", timestamp())}-${var.architecture}-ebs"
+  ami_name                  = "${var.prefix}-${var.flavor}-${var.virtualization_type}-${var.version}-${formatdate("YYYYMMDD", timestamp())}-${var.architecture}-${var.suffix}"
   ami_virtualization_type   = local.common_source.ami_virtualization_type
   ami_regions               = local.common_source.ami_regions
   ami_users                 = local.common_source.ami_users
@@ -133,7 +141,7 @@ source "amazon-ebs" "fck-nat" {
 }
 
 source "amazon-ebs" "fck-nat-nat64" {
-  ami_name                  = "fck-nat-nat64-${var.flavor}-${var.virtualization_type}-${var.version}-${formatdate("YYYYMMDD", timestamp())}-${var.architecture}-ebs"
+  ami_name                  = "${var.prefix}-nat64-${var.flavor}-${var.virtualization_type}-${var.version}-${formatdate("YYYYMMDD", timestamp())}-${var.architecture}-${var.suffix}"
   ami_virtualization_type   = local.common_source.ami_virtualization_type
   ami_regions               = local.common_source.ami_regions
   ami_users                 = local.common_source.ami_users
@@ -163,7 +171,7 @@ source "amazon-ebs" "fck-nat-nat64" {
 }
 
 build {
-  name = "fck-nat"
+  name    = "fck-nat"
   sources = ["source.amazon-ebs.fck-nat", "source.amazon-ebs.fck-nat-nat64"]
 
   # Install updates
@@ -178,7 +186,7 @@ build {
   # Install jool for NAT64
   provisioner "shell" {
     start_retry_timeout = "2m"
-    only = ["amazon-ebs.fck-nat-nat64"]
+    only                = ["amazon-ebs.fck-nat-nat64"]
     inline = [
       "sudo yum install gcc make elfutils-libelf-devel kernel6.12-devel-`uname -r` kernel6.12-headers-`uname -r` libnl3-devel iptables-devel dkms -y",
       "curl -L https://github.com/NICMx/Jool/releases/download/v${var.jool_version}/jool-${var.jool_version}.tar.gz -o- | tar xzf - --directory /tmp",
@@ -189,9 +197,9 @@ build {
       "sudo yum remove gcc make elfutils-libelf-devel kernel6.12-devel libnl3-devel iptables-devel -y"
     ]
   }
-  
+
   provisioner "file" {
-    source = "build/fck-nat-${var.version}-any.rpm"
+    source      = "build/fck-nat-${var.version}-any.rpm"
     destination = "/tmp/fck-nat-${var.version}-any.rpm"
   }
 


### PR DESCRIPTION
Refs #129.

This carries forward the useful parts of #129 on a maintainer-writable branch and addresses the review blocker from that PR.

Changes:
- Set the RPM package architecture to `noarch` and specify `--rpm-os linux` in `.fpm`.
- Add `prefix` and `suffix` Packer variables for AMI naming.
- Apply the same parameterized naming to both the regular and NAT64 AMI sources so `make publish` does not produce inconsistent names.
- Run `packer fmt` on `packer/fck-nat.pkr.hcl`.

Validation:
- `packer fmt -check packer/fck-nat.pkr.hcl`
- `packer validate -syntax-only -var version=0.0.0 packer/fck-nat.pkr.hcl`

Note: I could not push directly to #129 because its fork branch has `maintainerCanModify: false`.